### PR TITLE
Integrate leaderboard backend, persist state across tabs

### DIFF
--- a/ly_project/lib/Pages/WardInfo/LeaderboardTab/LeaderboardTable.dart
+++ b/ly_project/lib/Pages/WardInfo/LeaderboardTab/LeaderboardTable.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
-import 'package:ly_project/utils/constants.dart';
 
 class LeaderboardTable extends StatelessWidget {
   const LeaderboardTable({
     Key key,
     @required this.size,
     @required this.headerTexstyle,
+    @required this.performanceData,
   }) : super(key: key);
 
   final Size size;
   final TextStyle headerTexstyle;
+  final List<Map<String, String>> performanceData;
 
   @override
   Widget build(BuildContext context) {
@@ -46,12 +47,12 @@ class LeaderboardTable extends StatelessWidget {
           ListView.builder(
             physics: NeverScrollableScrollPhysics(),
             shrinkWrap: true,
-            itemCount: dummyPerformanceData.length,
+            itemCount: performanceData.length,
             itemBuilder: (BuildContext context, int index) {
               return Container(
                 decoration: BoxDecoration(
                   color: index % 2 == 0 ? Colors.white : Colors.blue[100],
-                  borderRadius: index != dummyPerformanceData.length - 1
+                  borderRadius: index != performanceData.length - 1
                       ? BorderRadius.zero
                       : BorderRadius.only(
                           bottomLeft: Radius.circular(8),
@@ -64,19 +65,19 @@ class LeaderboardTable extends StatelessWidget {
                     Container(
                         padding: EdgeInsets.only(left: size.width * 0.01),
                         width: size.width * 0.14,
-                        child: Text(dummyPerformanceData[index]["Rank"])),
+                        child: Text(performanceData[index]["Rank"])),
                     Container(
                         width: size.width * 0.31,
                         child: Text(
-                          dummyPerformanceData[index]["Ward"],
+                          performanceData[index]["Ward"],
                           softWrap: true,
                         )),
                     Container(
                         width: size.width * 0.3,
-                        child: Text(dummyPerformanceData[index]["Locality"],
+                        child: Text(performanceData[index]["Locality"],
                             softWrap: true)),
                     Container(
-                        child: Text(dummyPerformanceData[index]["Points"],
+                        child: Text(performanceData[index]["Points"],
                             softWrap: true)),
                   ],
                 ),

--- a/ly_project/lib/Pages/WardInfo/WardPerformanceTab/performance_tab.dart
+++ b/ly_project/lib/Pages/WardInfo/WardPerformanceTab/performance_tab.dart
@@ -10,7 +10,7 @@ class WardPerformance extends StatefulWidget {
   State<WardPerformance> createState() => _WardPerformanceState();
 }
 
-class _WardPerformanceState extends State<WardPerformance> {
+class _WardPerformanceState extends State<WardPerformance> with AutomaticKeepAliveClientMixin<WardPerformance> {
   String wardDdValue = WARDS[0];
   String durationDdValue = LEADERBOARD_DURATIONS[0];
   DateTime dateFrom, dateTo;
@@ -67,6 +67,7 @@ class _WardPerformanceState extends State<WardPerformance> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     Size size = MediaQuery.of(context).size;
 
     return SingleChildScrollView(
@@ -157,4 +158,7 @@ class _WardPerformanceState extends State<WardPerformance> {
       ),
     );
   }
+
+  @override
+bool get wantKeepAlive => true;
 }

--- a/ly_project/lib/Services/LeaderboardServices.dart
+++ b/ly_project/lib/Services/LeaderboardServices.dart
@@ -1,0 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:ly_project/utils/constants.dart';
+
+/// Contains helper methods for processing the ward leaderboard data
+class LeaderboardServices {
+  static Stream<QuerySnapshot> getWardScores({String duration = "today"}) =>
+      FirebaseFirestore.instance
+          .collection("wards")
+          .orderBy(L_DURATIONS_TO_DB_FIELD_MAP[duration], descending: true)
+          .snapshots();
+
+  static List<Map<String, String>> formatScores({
+    @required String duration,
+    @required List<QueryDocumentSnapshot> wardList
+    }) {
+    List<Map<String, String>> result = new List<Map<String, String>>();
+    String field = L_DURATIONS_TO_DB_FIELD_MAP[duration];
+
+    wardList.asMap().forEach((index, wardDoc) {
+      result.add({
+        "Rank": "${index + 1}",
+        "Ward": wardDoc.data()["ward"],
+        "Locality": wardDoc.data()["locality"],
+        "Points": wardDoc.data()[field].toString()
+      });
+    });
+
+    return result;
+  }
+}

--- a/ly_project/lib/utils/constants.dart
+++ b/ly_project/lib/utils/constants.dart
@@ -35,6 +35,14 @@ const LEADERBOARD_DURATIONS = [
   "All Time"
 ];
 
+const Map<String, String> L_DURATIONS_TO_DB_FIELD_MAP = {
+  "Today": "realtimeScore",
+  "This Week": "weeklyScore",
+  "This Month": "monthlyScore",
+  "This Year": "yearlyScore",
+  "All Time": "lifetimeScore"
+  };
+
 const OCCUPATIONS = ["Service", "Student", "Business", "Other", "Housewife"];
 
 const EMAIL_REGEX =


### PR DESCRIPTION
1. The leaderboard tab now fetches ordered leaderboard data from Firebase.
2. Two tabs (Ward Performance and leaderboard) inside the Ward Information page now persist states when switched across.